### PR TITLE
Simplified mwdblib code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ API bindings for mwdb.cert.pl service, supporting both Python 2.x/3.x versions. 
 
 ## Usage and installation
 
-```buildoutcfg
+```
 $ pip install mwdblib
 
 or with CLI

--- a/src/blob.py
+++ b/src/blob.py
@@ -1,34 +1,36 @@
-from .object import MWDBObject, lazy_property
+from .object import MWDBObject
 
 
 class MWDBBlob(MWDBObject):
-    URL_PATTERN = "blob/{id}"
+    URL_TYPE = "blob"
     TYPE = "text_blob"
 
-    @staticmethod
-    def create(api, data):
-        return MWDBBlob(api, data)
-
-    @lazy_property()
+    @property
     def blob_name(self):
         """
         Blob name
         """
-        return self.data.get("blob_name")
+        if "blob_name" not in self.data:
+            self._load()
+        return self.data["blob_name"]
 
-    @lazy_property()
+    @property
     def blob_size(self):
         """
         Blob size in bytes
         """
-        return self.data.get("blob_size")
+        if "blob_size" not in self.data:
+            self._load()
+        return self.data["blob_size"]
 
-    @lazy_property()
+    @property
     def blob_type(self):
         """
         Blob semantic type
         """
-        return self.data.get("blob_type")
+        if "blob_type" not in self.data:
+            self._load()
+        return self.data["blob_type"]
 
     @property
     def name(self):
@@ -51,7 +53,7 @@ class MWDBBlob(MWDBObject):
         """
         return self.blob_type
 
-    @lazy_property()
+    @property
     def content(self):
         """
         Contains blob content
@@ -59,19 +61,38 @@ class MWDBBlob(MWDBObject):
         .. versionchanged:: 3.0.0
            Returned type is guaranteed to be utf8-encoded bytes
         """
-        content = self.data.get("content")
-        if content is not None and not isinstance(content, bytes):
+        if "content" not in self.data:
+            self._load()
+        content = self.data["content"]
+        if not isinstance(content, bytes):
             content = content.encode("utf-8")
         return content
 
-    @lazy_property()
+    @property
+    def config(self):
+        """
+        Returns latest config related with this object
+
+        :rtype: :class:`MWDBConfig` or None
+        :return: Latest configuration if found
+        """
+        from .config import MWDBConfig
+        if "latest_config" not in self.data:
+            self._load()
+        if self.data["latest_config"] is None:
+            return None
+        return MWDBConfig(self.api, self.data["latest_config"])
+
+    @property
     def last_seen(self):
         """
         :rtype: datetime.datetime
         :return: datetime object when blob was last seen in MWDB
         """
         import dateutil.parser
-        return dateutil.parser.parse(self.data["last_seen"]) if "last_seen" in self.data else None
+        if "last_seen" not in self.data:
+            self._load()
+        return dateutil.parser.parse(self.data["last_seen"])
 
 
 # Backwards compatibility

--- a/src/comment.py
+++ b/src/comment.py
@@ -10,6 +10,13 @@ class MWDBComment(MWDBElement):
         self.parent = parent
 
     @property
+    def id(self):
+        """
+        Comment identifier
+        """
+        return self.data["id"]
+
+    @property
     def author(self):
         """
         Comment author
@@ -44,3 +51,7 @@ class MWDBComment(MWDBElement):
         :raises: requests.exceptions.HTTPError
         """
         self.api.delete("object/{}/comment/{}".format(self.parent.id, self.id))
+
+
+# Backwards compatibility
+MalwarecageComment = MWDBComment

--- a/src/config.py
+++ b/src/config.py
@@ -1,52 +1,54 @@
-from .object import MWDBObject, lazy_property
+from .object import MWDBObject
 
 
 class MWDBConfig(MWDBObject):
-    URL_PATTERN = "config/{id}"
+    URL_TYPE = "config"
     TYPE = "static_config"
 
-    @staticmethod
-    def create(api, data):
-        return MWDBConfig(api, data)
-
-    def _update(self, data):
-        if "cfg" in data:
-            from .blob import MWDBBlob
-            data = dict(data)
-            data["config"] = {k: (MWDBBlob(self.api, {"id": v["in-blob"]})
-                                  if isinstance(v, dict) and "in-blob" in v
-                                  else v)
-                              for k, v in data["cfg"].items()}
-        super(MWDBConfig, self)._update(data)
-
-    @lazy_property()
+    @property
     def family(self):
         """
         Configuration family
         """
-        return self.data.get("family")
+        if "family" not in self.data:
+            self._load()
+        return self.data["family"]
 
-    @lazy_property()
+    @property
     def type(self):
         """
         Configuration type ('static' or 'dynamic')
         """
-        return self.data.get("config_type")
+        if "config_type" not in self.data:
+            self._load()
+        return self.data["config_type"]
 
-    @lazy_property()
-    def cfg(self):
-        """
-        dict object with configuration
-        """
-        return self.data.get("config")
-
-    @lazy_property()
+    @property
     def config_dict(self):
         """
         raw dict object with configuration
         (in-blob keys are not mapped to :class:`MWDBBlob` objects)
         """
-        return self.data.get("cfg")
+        if "cfg" not in self.data:
+            self._load()
+        return self.data["cfg"]
+
+    def _map_blobs(self, config):
+        from .blob import MWDBBlob
+        return {
+            key: (
+                MWDBBlob(self.api, {"id": value["in-blob"]})
+                if isinstance(value, dict) and "in-blob" in value
+                else value
+            ) for key, value in config.items()
+        }
+
+    @property
+    def config(self):
+        """
+        dict object with configuration
+        """
+        return self._map_blobs(self.config_dict)
 
     @property
     def content(self):
@@ -63,13 +65,13 @@ class MWDBConfig(MWDBObject):
         return content
 
     @property
-    def config(self):
+    def cfg(self):
         """
         dict object with configuration
 
         .. seealso:: :py:attr:`config_dict`
         """
-        return self.cfg
+        return self.config
 
 
 # Backwards compatibility

--- a/src/core.py
+++ b/src/core.py
@@ -20,10 +20,10 @@ except ImportError:
 
 class MWDB(object):
     """
-    Main object used for communication with MWDB
+    Main object used for communication with MWDB REST API
 
     :param api: Custom :class:`APIClient` used to communicate with MWDB
-    :type api: :class:`APIClient`, optional
+    :type api: :class:`mwdblib.APIClient`, optional
     :param api_key: API key used for authentication (omit if password-based authentication is used)
     :type api_key: str, optional
 
@@ -102,9 +102,8 @@ class MWDB(object):
                 if query is not None:
                     params["query"] = query
                 # 'object', 'file', 'config' or 'blob'?
-                endpoint = object_type.URL_PATTERN.split("/")[0]
-                result = self.api.get(endpoint, params=params)
-                key = endpoint+"s"
+                result = self.api.get(object_type.URL_TYPE, params=params)
+                key = object_type.URL_TYPE + "s"
                 if key not in result or len(result[key]) == 0:
                     return
                 for obj in result[key]:
@@ -306,7 +305,8 @@ class MWDB(object):
 
     def _query(self, object_type, hash, raise_not_found):
         try:
-            result = self.api.get(object_type.URL_PATTERN.format(id=hash))
+            url_pattern = object_type.URL_TYPE + "/{id}"
+            result = self.api.get(url_pattern.format(id=hash))
             return object_type.create(self.api, result)
         except ObjectNotFoundError:
             if not raise_not_found:

--- a/src/file.py
+++ b/src/file.py
@@ -1,58 +1,70 @@
-from .object import MWDBObject, lazy_property
+from .object import MWDBObject
 
 
 class MWDBFile(MWDBObject):
-    URL_PATTERN = "file/{id}"
+    URL_TYPE = "file"
     TYPE = "file"
 
     def __init__(self, *args, **kwargs):
-        self.preloaded_content = None
+        self._content = None
         super(MWDBFile, self).__init__(*args, **kwargs)
 
-    @staticmethod
-    def create(api, data):
-        return MWDBFile(api, data)
-
-    @lazy_property()
+    @property
     def md5(self):
-        return self.data.get("md5")
+        if "md5" not in self.data:
+            self._load()
+        return self.data["md5"]
 
-    @lazy_property()
+    @property
     def sha1(self):
-        return self.data.get("sha1")
+        if "sha1" not in self.data:
+            self._load()
+        return self.data["sha1"]
 
-    @lazy_property()
+    @property
     def sha512(self):
-        return self.data.get("sha512")
+        if "sha512" not in self.data:
+            self._load()
+        return self.data["sha512"]
 
-    @lazy_property()
+    @property
     def crc32(self):
-        return self.data.get("crc32")
+        if "crc32" not in self.data:
+            self._load()
+        return self.data["crc32"]
 
-    @lazy_property()
+    @property
     def ssdeep(self):
-        return self.data.get("ssdeep")
+        if "ssdeep" not in self.data:
+            self._load()
+        return self.data["ssdeep"]
 
-    @lazy_property()
+    @property
     def file_name(self):
         """
         Sample original name
         """
-        return self.data.get("file_name")
+        if "file_name" not in self.data:
+            self._load()
+        return self.data["file_name"]
 
-    @lazy_property()
+    @property
     def file_size(self):
         """
         Sample size in bytes
         """
-        return self.data.get("file_size")
+        if "file_size" not in self.data:
+            self._load()
+        return self.data["file_size"]
 
-    @lazy_property()
+    @property
     def file_type(self):
         """
         Sample type
         """
-        return self.data.get("file_type")
+        if "file_type" not in self.data:
+            self._load()
+        return self.data["file_type"]
 
     @property
     def name(self):
@@ -80,9 +92,26 @@ class MWDBFile(MWDBObject):
         """
         Returns file contents, calling :py:meth:`MWDBFile.download` if contents were not loaded yet
         """
-        if self.preloaded_content is None:
-            self.preloaded_content = self.download()
-        return self.preloaded_content
+        if self._content is None:
+            self._content = self.download()
+        return self._content
+
+    @property
+    def config(self):
+        """
+        Returns latest config related with this object
+
+        :rtype: :class:`MWDBConfig` or None
+        :return: Latest configuration if found
+        """
+        from .config import MWDBConfig
+        if "latest_config" not in self.data:
+            self._load()
+        return (
+            MWDBConfig(self.api, self.data["latest_config"])
+            if self.data["latest_config"] is not None
+            else None
+        )
 
     def download(self):
         """


### PR DESCRIPTION
- Get rid of `lazy_property` and `mapper` methods - everything is inside property code.
- Fixed `APIClient` documentation
- Instead of `URL_PATTERN`, MWDBObject classes declare `URL_TYPE` and `TYPE` (like in https://github.com/CERT-Polska/mwdblib/pull/8)