### PR TITLE
Fix table widths and headers for CLI using beautifultable 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name="mwdblib",
               "click>=7.0",
               "click-default-group",
               "keyring>=18.0.0",
-              "beautifultable>=0.8.0",
+              "beautifultable>=1.0.0",
               "humanize>=0.5.1"
           ]
       },

--- a/src/cli/formatters/tabular.py
+++ b/src/cli/formatters/tabular.py
@@ -15,7 +15,7 @@ except ImportError:
 class TabularFormatter(ObjectFormatter):
     def format_attr_table(self, data):
         term_width, term_height = click.get_terminal_size()
-        table = beautifultable.BeautifulTable(max_width=term_width,
+        table = beautifultable.BeautifulTable(maxwidth=term_width,
                                               default_alignment=beautifultable.ALIGN_LEFT)
         table.set_style(beautifultable.STYLE_NONE)
         for key, formatter, value in data:
@@ -27,15 +27,15 @@ class TabularFormatter(ObjectFormatter):
 
     def format_table(self, headers, widths, row_formatter, rows):
         term_width, term_height = click.get_terminal_size()
-        table = beautifultable.BeautifulTable(max_width=term_width,
+        table = beautifultable.BeautifulTable(maxwidth=term_width,
                                               default_alignment=beautifultable.ALIGN_LEFT)
-        table.column_headers = headers
+        table.columns.header = headers
         sum_width = None
         for width_set in widths:
             column_widths, expandable_index = width_set[:-1], width_set[-1]
             sum_width = sum(column_widths) + 6  # Table characters width
             if term_width > sum_width:
-                table._column_widths = (
+                table.columns.width = (
                         column_widths[:expandable_index] +
                         [term_width - sum_width + column_widths[expandable_index]] +
                         column_widths[expandable_index+1:]


### PR DESCRIPTION
In current version, `mwdb list` shows warnings and columns are shrinked.
```
/usr/local/lib/python3.8/dist-packages/beautifultable/utils.py:136: FutureWarning: 'max_width' has been deprecated in 'v1.0.0' and will be removed in 'v1.2.0'. Use 'maxwidth' instead.
  warnings.warn(message, FutureWarning)
/usr/local/lib/python3.8/dist-packages/beautifultable/utils.py:113: FutureWarning: 'BeautifulTable.column_headers' has been deprecated in 'v1.0.0' and will be removed in 'v1.2.0'. Use 'BTColumnCollection.header' instead.
  warnings.warn(message, FutureWarning)
```

Closes #11 