### PR TITLE
Switch documentation theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ from src import __version__  # noqa: E402
 # -- Project information -----------------------------------------------------
 
 project = 'mwdblib'
-copyright = '2019, CERT Polska'
+copyright = '2020, CERT Polska'
 author = 'CERT Polska'
 
 # The full version, including alpha/beta/rc tags
@@ -35,7 +35,8 @@ release = __version__
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
-    "sphinx.ext.inheritance_diagram"
+    "sphinx.ext.inheritance_diagram",
+    "sphinx_rtd_theme"
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -53,7 +54,7 @@ master_doc = 'index'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinxdoc'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
-Sphinx==2.0.1    
+Sphinx==3.0.3
 sphinx-autodoc-annotation==1.0.post1
-sphinx-autodoc-typehints==1.6.0    
+sphinx-autodoc-typehints==1.10.3
+sphinx-rtd-theme==0.5.0


### PR DESCRIPTION
We use `sphinx-rtd` practically everywhere else, the version numbers were copied from https://github.com/CERT-Polska/karton/