### PR TITLE
Fix listen_* methods without valid last_object provided

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -168,11 +168,13 @@ class MWDB(object):
 
     def _listen(self, last_object, object_type, blocking=True, interval=15, query=None):
         if last_object is None:
-            last_object = next(self._recent(object_type, query=query))
+            last_object = next(self._recent(object_type, query=query), None)
             # If there are no elements (even first element): just get new samples from now on
             if last_object is not None:
                 last_id = last_object.id
                 last_time = last_object.upload_time
+            else:
+                last_id = last_time = None
         elif isinstance(last_object, MWDBObject):
             # If we are requesting for typed objects, we should additionally check the object type
             if object_type is not MWDBObject and not isinstance(last_object, object_type):
@@ -189,10 +191,10 @@ class MWDB(object):
         while True:
             objects = []
             for obj in self._recent(object_type, query=query):
-                if obj.id == last_id:
+                if last_id and obj.id == last_id:
                     break
 
-                if obj.upload_time < last_time:
+                if last_time and obj.upload_time < last_time:
                     raise RuntimeError(
                         "Newly fetched object [{}] is older than the pivot [{}]".format(
                             obj.id, last_id

--- a/src/core.py
+++ b/src/core.py
@@ -170,42 +170,33 @@ class MWDB(object):
         if last_object is None:
             last_object = next(self._recent(object_type, query=query), None)
             # If there are no elements (even first element): just get new samples from now on
-            if last_object is not None:
-                last_id = last_object.id
-                last_time = last_object.upload_time
-            else:
-                last_id = last_time = None
         elif isinstance(last_object, MWDBObject):
             # If we are requesting for typed objects, we should additionally check the object type
             if object_type is not MWDBObject and not isinstance(last_object, object_type):
                 raise TypeError("latest_object type must be 'str' or '{}'".format(object_type.__name__))
             # If object instance provided: get ID from instance
-            last_id = last_object.id
-            last_time = last_object.upload_time
         else:
             # If not: first check whether object exists in repository
-            last_obj = self._query(object_type, last_object, raise_not_found=True)
-            last_id = last_obj.id
-            last_time = last_obj.upload_time
+            last_object = self._query(object_type, last_object, raise_not_found=True)
 
         while True:
             objects = []
             for obj in self._recent(object_type, query=query):
-                if last_id and obj.id == last_id:
-                    break
+                if last_object:
+                    if obj.id == last_object.id:
+                        break
 
-                if last_time and obj.upload_time < last_time:
-                    raise RuntimeError(
-                        "Newly fetched object [{}] is older than the pivot [{}]".format(
-                            obj.id, last_id
+                    if obj.upload_time < last_object.upload_time:
+                        raise RuntimeError(
+                            "Newly fetched object [{}] is older than the pivot [{}]".format(
+                                obj.id, last_object.id
+                            )
                         )
-                    )
                 objects.append(obj)
 
             # Return fetched objects in reversed order (from oldest to latest)
             for obj in objects[::-1]:
-                last_id = obj.id
-                last_time = obj.upload_time
+                last_object = obj
                 yield obj
             if blocking:
                 time.sleep(interval)


### PR DESCRIPTION
If `query` returns none results (e.g. query for non-existent tag), _listen throws RuntimeError("generator raised StopIteration")

The same bug was in 3.3.1 release when empty MWDB Core instance was queried.