### PR TITLE
Decode api_key bytes before parsing as JSON

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -80,7 +80,7 @@ class APIClient(object):
         self.api_key = api_key
         if self.api_key is not None:
             try:
-                self.logged_user = json.loads(base64.b64decode(self.api_key.split(".")[1] + "=="))["login"]
+                self.logged_user = json.loads(base64.b64decode(self.api_key.split(".")[1] + "==").decode())["login"]
             except Exception:
                 raise InvalidCredentialsError("Invalid API key format. Verify whether actual token is provided "
                                               "instead of its UUID.")


### PR DESCRIPTION
As per #4 `json.loads`:

> Changed in version 3.6: s can now be of type bytes or bytearray. The input encoding should be UTF-8, UTF-16 or UTF-32.

Because other python versions support the argument as `str` we just have to decode it from bytes to str (I don't think we have to worry about encoding other than UTF-8)


closes #4 