### PR TITLE
Docs: fixed typo in file.download, search_files instead of search_file

### DIFF
--- a/src/file.py
+++ b/src/file.py
@@ -124,7 +124,7 @@ class MWDBFile(MWDBObject):
 
         .. code-block:: python
 
-           dropper = next(mwdb.search_file('file.size:[0 TO 1000] AND file.name:"*.vbs"'))
+           dropper = next(mwdb.search_files('file.size:[0 TO 1000] AND file.name:"*.vbs"'))
 
            with open(dropper.file_name, "wb") as f:
                f.write(dropper.download())


### PR DESCRIPTION
A minor typo in https://github.com/CERT-Polska/mwdblib/blob/master/src/file.py#L127
Using as-is will raise : `AttributeError: 'MWDB' object has no attribute 'search_file'`