### PR TITLE
Use datetime.fromisoformat instead of python-dateutil package

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.8]
+        python: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install black==21.10b0 flake8==3.8.3 isort==5.10.1 mypy==0.910 pytest
-        pip install types-python-dateutil types-requests
+        pip install types-requests
         pip install .
     - run: isort --check mwdblib/
     - run: black --check mwdblib/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 API bindings for [mwdb.cert.pl](https://mwdb.cert.pl) service or your own instance of [MWDB](https://github.com/CERT-Polska/mwdb-core).
 Use it if you want to automate data uploading/fetching from MWDB or have some ipython-based CLI.
 
+Latest version requires Python >= 3.7.
+
 ## Usage and installation
 
 ```

--- a/mwdblib/blob.py
+++ b/mwdblib/blob.py
@@ -1,10 +1,9 @@
+import datetime
 from typing import TYPE_CHECKING, Optional, cast
 
 from .object import MWDBObject
 
 if TYPE_CHECKING:
-    import datetime
-
     from .config import MWDBConfig
 
 
@@ -93,8 +92,6 @@ class MWDBBlob(MWDBObject):
         """
         :return: datetime object when blob was last seen in MWDB
         """
-        import dateutil.parser
-
         if "last_seen" not in self.data:
             self._load()
-        return dateutil.parser.parse(self.data["last_seen"])
+        return datetime.datetime.fromisoformat(self.data["last_seen"])

--- a/mwdblib/comment.py
+++ b/mwdblib/comment.py
@@ -1,10 +1,9 @@
+import datetime
 from typing import TYPE_CHECKING, cast
 
 from .object import MWDBElement
 
 if TYPE_CHECKING:
-    import datetime
-
     from .api import APIClient
     from .object import MWDBElementData, MWDBObject
 
@@ -39,9 +38,7 @@ class MWDBComment(MWDBElement):
         """
         Comment timestamp
         """
-        import dateutil.parser
-
-        return dateutil.parser.parse(self.data["timestamp"])
+        return datetime.datetime.fromisoformat(self.data["timestamp"])
 
     @property
     def comment(self) -> str:

--- a/mwdblib/object.py
+++ b/mwdblib/object.py
@@ -1,9 +1,8 @@
+import datetime
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 if TYPE_CHECKING:
-    import datetime
-
     from .api import APIClient
     from .comment import MWDBComment
     from .share import MWDBShare
@@ -172,11 +171,9 @@ class MWDBObject(MWDBElement):
 
         :return: datetime object with object upload timestamp
         """
-        import dateutil.parser
-
         if "upload_time" not in self.data:
             self._load()
-        return dateutil.parser.parse(self.data["upload_time"])
+        return datetime.datetime.fromisoformat(self.data["upload_time"])
 
     @property
     def parents(self) -> List["MWDBObject"]:

--- a/mwdblib/share.py
+++ b/mwdblib/share.py
@@ -1,10 +1,9 @@
+import datetime
 from typing import TYPE_CHECKING, Optional, cast
 
 from .object import MWDBElement, MWDBObject
 
 if TYPE_CHECKING:
-    import datetime
-
     from .api import APIClient
     from .object import MWDBElementData
 
@@ -82,9 +81,7 @@ class MWDBShare(MWDBElement):
 
         :return: datetime object with object share timestamp
         """
-        import dateutil.parser
-
-        return dateutil.parser.parse(self.data["access_time"])
+        return datetime.datetime.fromisoformat(self.data["access_time"])
 
     @property
     def group(self) -> str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ max-line-length = 88
 extend-ignore = E203, W503
 
 [mypy]
-python_version = 3.6
+python_version = 3.7
 warn_return_any = True
 disallow_untyped_defs = True
 check_untyped_defs = True

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ setup(
     packages=["mwdblib", "mwdblib.api", "mwdblib.cli", "mwdblib.cli.formatters"],
     package_data={"mwdblib": ["py.typed"]},
     url="https://github.com/CERT-Polska/mwdblib",
-    python_requires=">=3.6",
-    install_requires=["requests", "python-dateutil", "keyring>=18.0.0"],
+    python_requires=">=3.7",
+    install_requires=["requests", "keyring>=18.0.0"],
     extras_require={
         "cli": [
             "click>=7.0",


### PR DESCRIPTION
Requires Python 3.7 but lifetime of 3.6 is going to end


3.6 | 4 years and 11 months ago(23 Dec 2016) | Ends in 1 month and 6 days(23 Dec 2021) | 3.6.15
-- | -- | -- | --


