### PR TITLE
Report confirmation messages to stderr instead of stdout

### DIFF
--- a/mwdblib/cli/formatters/abstract.py
+++ b/mwdblib/cli/formatters/abstract.py
@@ -73,4 +73,4 @@ class ObjectFormatter:
         self.print_lines(list_formatter(objects))
 
     def print_confirmation(self, message, **params):
-        click.echo(message.format(**params))
+        click.echo(message.format(**params), err=True)

--- a/mwdblib/cli/formatters/tabular.py
+++ b/mwdblib/cli/formatters/tabular.py
@@ -248,5 +248,6 @@ class TabularFormatter(ObjectFormatter):
                     )
                     for k, v in params.items()
                 }
-            )
+            ),
+            err=True
         )

--- a/mwdblib/cli/formatters/tabular.py
+++ b/mwdblib/cli/formatters/tabular.py
@@ -249,5 +249,5 @@ class TabularFormatter(ObjectFormatter):
                     for k, v in params.items()
                 }
             ),
-            err=True
+            err=True,
         )


### PR DESCRIPTION
Right now, the `fetch` command outputs the confirmation message to stdout. This is a big no no if we're trying to read the output using jq or other tools.

```shell
mwdb fetch 543072873615f9afd57d9c4b9d95ae23fe2f15d29825c42c856094ea851421a8 - 2>/dev/null
{
    "type": "agenttesla",
    "email": "info@nexcourier.ae",
    "raw_cfg": {
        "in-blob": "fc3029e8d40cfa3a6f318bdd49b3dc3b1015dd5593d008e3388836f91e0643e1"
    },
    "email_to": "sinooceancnlogistice@vivaldi.net",
    "exfiltration_method": "smtp"
}
Downloaded 543072873615f9afd57d9c4b9d95ae23fe2f15d29825c42c856094ea851421a8 => -
```

I'm not 100% sure about the designation of `print_confirmation` though, it seems like it should be there just to report some details about the command success. But on the other hand, `-o short` seems to be using it for reporting the command output?

closes #75 