### PR TITLE
Disable autologin and keyring in CLI

### DIFF
--- a/mwdblib/api/options.py
+++ b/mwdblib/api/options.py
@@ -219,11 +219,13 @@ class APIClientOptions:
                 keyring.set_password(
                     f"mwdb:{self.api_url}", self.username, self.password
                 )
+            self.config_parser.set(instance_section, "use_keyring", "1")
         else:
             if self.api_key:
                 self.config_parser.set(instance_section, "api_key", self.api_key)
             else:
                 self.config_parser.set(instance_section, "password", self.password)
+            self.config_parser.set(instance_section, "use_keyring", "0")
         # Perform configuration writeback
         if self.config_path:
             with self.config_path.open("w") as f:

--- a/mwdblib/cli/login.py
+++ b/mwdblib/cli/login.py
@@ -11,6 +11,11 @@ from .main import main, pass_mwdb
 @click.option(
     "--password", "-p", type=str, default=None, help="MWDB password (default: ask)"
 )
+@click.option(
+    "--use-keyring/--no-keyring",
+    default=None,
+    help="Don't use keyring, store credentials in plaintext",
+)
 @click.option("--via-api-key", "-A", is_flag=True, help="Use API key provided by stdin")
 @click.option(
     "--api-key",
@@ -19,17 +24,21 @@ from .main import main, pass_mwdb
     default=None,
     help="API key token (default: password-based authentication)",
 )
-@pass_mwdb
+@pass_mwdb(autologin=False)
 @click.pass_context
-def login_command(ctx, mwdb, username, password, via_api_key, api_key):
+def login_command(ctx, mwdb, username, password, use_keyring, via_api_key, api_key):
     """Store credentials for MWDB authentication"""
     if via_api_key:
         api_key = click.prompt("Provide your API key token", hide_input=True)
+
     if api_key is None:
         if username is None:
             username = click.prompt("Username")
         if password is None:
             password = click.prompt("Password", hide_input=True)
+
+    if use_keyring is not None:
+        mwdb.api.options.use_keyring = use_keyring
 
     try:
         # Try to use credentials
@@ -43,10 +52,16 @@ def login_command(ctx, mwdb, username, password, via_api_key, api_key):
         click.echo("Error: Login failed - {}".format(str(e)), err=True)
         ctx.abort()
     mwdb.api.options.store_credentials()
+    click.echo(
+        f"Logged in successfully to {mwdb.api.options.api_url} "
+        f"as {mwdb.api.logged_user}",
+        err=True,
+    )
 
 
 @main.command("logout")
-@pass_mwdb
+@pass_mwdb(autologin=False)
 def logout_command(mwdb):
     """Reset stored credentials"""
     mwdb.api.options.clear_stored_credentials()
+    click.echo(f"Logged out successfully from {mwdb.api.options.api_url}", err=True)

--- a/mwdblib/cli/main.py
+++ b/mwdblib/cli/main.py
@@ -8,37 +8,49 @@ from ..core import MWDB
 from ..exc import MWDBError, NotAuthenticatedError
 
 
-def pass_mwdb(fn):
-    @click.option("--api-url", type=str, default=None, help="URL to MWDB instance API")
-    @click.option(
-        "--config-path", type=str, default=None, help="Alternative configuration path"
-    )
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        ctx = get_current_context()
-        mwdb_options = {}
-        api_url = kwargs.pop("api_url")
-        if api_url:
-            mwdb_options["api_url"] = api_url
-        config_path = kwargs.pop("config_path")
-        if config_path:
-            mwdb_options["config_path"] = config_path
-        mwdb = MWDB(**mwdb_options)
-        try:
-            return fn(mwdb=mwdb, *args, **kwargs)
-        except NotAuthenticatedError:
-            click.echo(
-                "Error: Not authenticated. Use `mwdb login` first to set credentials.",
-                err=True,
-            )
-            ctx.abort()
-        except MWDBError as error:
-            click.echo(
-                "{}: {}".format(error.__class__.__name__, error.args[0]), err=True
-            )
-            ctx.abort()
+def pass_mwdb(*fn, autologin=True):
+    def uses_mwdb(fn):
+        @click.option(
+            "--api-url", type=str, default=None, help="URL to MWDB instance API"
+        )
+        @click.option(
+            "--config-path",
+            type=str,
+            default=None,
+            help="Alternative configuration path",
+        )
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            ctx = get_current_context()
+            mwdb_options = {}
+            api_url = kwargs.pop("api_url")
+            if api_url:
+                mwdb_options["api_url"] = api_url
+            config_path = kwargs.pop("config_path")
+            if config_path:
+                mwdb_options["config_path"] = config_path
+            mwdb = MWDB(autologin=autologin, **mwdb_options)
+            try:
+                return fn(mwdb=mwdb, *args, **kwargs)
+            except NotAuthenticatedError:
+                click.echo(
+                    "Error: Not authenticated. Use `mwdb login` first "
+                    "to set credentials.",
+                    err=True,
+                )
+                ctx.abort()
+            except MWDBError as error:
+                click.echo(
+                    "{}: {}".format(error.__class__.__name__, error.args[0]), err=True
+                )
+                ctx.abort()
 
-    return wrapper
+        return wrapper
+
+    if fn:
+        return uses_mwdb(fn[0])
+    else:
+        return uses_mwdb
 
 
 @click.group()

--- a/mwdblib/core.py
+++ b/mwdblib/core.py
@@ -36,6 +36,8 @@ class MWDB:
     :param api_key: MWDB API key
     :param username: MWDB account username
     :param password: MWDB account password
+    :param autologin: Login automatically using credentials stored in configuration
+        or provided in arguments (default: True)
     :param verify_ssl: Verify SSL certificate correctness (default: True)
     :param obey_ratelimiter: If ``False``, HTTP 429 errors will cause an exception
         like all other error codes.
@@ -77,6 +79,9 @@ class MWDB:
     .. versionadded:: 4.0.0
        Added ``use_keyring``, ``emit_warnings`` and ``config_path`` options.
        ``username`` and ``password`` can be passed directly to the constructor.
+
+    .. versionadded:: 4.4.0
+       Added ``autologin`` option.
 
     Usage example:
 


### PR DESCRIPTION
There is really annoying problem that occurs when keyring is unsupported on current platform.

- There is no option to avoid keyring in CLI other than changing option manually in config
- `mwdb login` does pre-login using stored credentials before prompting for actual credentials. The same for `mwdb logout`
- It would be also nice to prompt user which instance is actually used