### PR TITLE
Add remove_comment function to object

### DIFF
--- a/mwdblib/object.py
+++ b/mwdblib/object.py
@@ -387,7 +387,6 @@ class MWDBObject(MWDBElement):
         )
         self._expire("attributes")
 
-    @APIClient.requires("2.6.0")
     def remove_comment(self, comment_id: int) -> None:
         """
         Remove specific comment from object

--- a/mwdblib/object.py
+++ b/mwdblib/object.py
@@ -387,6 +387,17 @@ class MWDBObject(MWDBElement):
         )
         self._expire("attributes")
 
+    @APIClient.requires("2.6.0")
+    def remove_comment(self, comment_id: int) -> None:
+        """
+        Remove specific comment from object
+
+        :param comment_id: Comment id
+        :type comment_id: int
+        """
+        self.api.delete(f"object/{self.id}/comment/{comment_id}")
+        self._expire("comments")
+
     @add_attribute.fallback("2.0.0")
     def _add_attribute_fallback(self, key: str, value: str) -> None:
         self._add_metakey(key, value)


### PR DESCRIPTION
Fixes #86 

I've based my remove_comment function on remove_attribute. Not 100% sure about `requires("2.6.0")` but sounds likely.