### PR TITLE
Add count param in methods

### DIFF
--- a/mwdblib/core.py
+++ b/mwdblib/core.py
@@ -201,7 +201,7 @@ class MWDB:
             files = islice(mwdb.recent_files(), 25)
             print([(f.name, f.tags) for f in files])
 
-        :param chunk_size: Number of files returned per API request
+        :param chunk_size: Number of objects returned per API request
         :type chunk_size: int
         :rtype: Iterator[:class:`MWDBObject`]
         :raises: requests.exceptions.HTTPError
@@ -630,7 +630,7 @@ class MWDB:
         :rtype: Iterator[:class:`MWDBFile`]
         :raises: requests.exceptions.HTTPError
         """
-        return self._recent(MWDBFile, query, chunk_size)
+        return self._recent(MWDBFile, query, chunk_size=chunk_size)
 
     def search_configs(
         self, query: str, chunk_size: Optional[int] = None

--- a/mwdblib/core.py
+++ b/mwdblib/core.py
@@ -160,9 +160,9 @@ class MWDB:
         Generic implementation of recent_* methods
         """
         try:
-            last_object: Optional[MWDBObject] = None
+            last_object = older_than
             while True:
-                params = {"older_than": older_than.id} if older_than else {}
+                params = {"older_than": last_object.id} if last_object else {}
                 if query is not None:
                     params["query"] = query
                 if count is not None:

--- a/mwdblib/core.py
+++ b/mwdblib/core.py
@@ -166,7 +166,7 @@ class MWDB:
                 if query is not None:
                     params["query"] = query
                 if count is not None:
-                    params["count"] = count
+                    params["count"] = str(count)
                 # 'object', 'file', 'config' or 'blob'?
                 result = self.api.get(object_type.URL_TYPE, params=params)
                 key = object_type.URL_TYPE + "s"


### PR DESCRIPTION
Now it's possible to set number of objects returned by API endpoints (`count` parameter in endpoints)

closes #89 