### PR TITLE
Don't gather download token for authenticated file download

### DIFF
--- a/mwdblib/file.py
+++ b/mwdblib/file.py
@@ -144,10 +144,7 @@ class MWDBFile(MWDBObject):
            print("Downloaded {}".format(dropper.file_name))
         """
         download_endpoint = "file/{id}/download".format(**self.data)
-        token = self.api.post(download_endpoint)["token"]
-        return cast(
-            bytes, self.api.get(download_endpoint, params={"token": token}, raw=True)
-        )
+        return cast(bytes, self.api.get(download_endpoint, raw=True))
 
     @download.fallback("2.0.0")
     def download_legacy(self) -> bytes:


### PR DESCRIPTION
Download token is needed only for convenient downloads from UI, where we can't easily pass Authorization header to the request. Using direct call to API, we need to make only one request to download file contents.

MWDB Core code that handles authenticated download:

https://github.com/CERT-Polska/mwdb-core/blob/3be33c65e25419da89212afa174415d58d908fc8/mwdb/resources/file.py#L441-L445